### PR TITLE
Add linkedca DNS entry to GCP

### DIFF
--- a/gcp/dns.tf
+++ b/gcp/dns.tf
@@ -39,6 +39,15 @@ resource "google_dns_record_set" "web_api_scim" {
   rrdatas      = [google_compute_address.smallstep_address.address]
 }
 
+resource "google_dns_record_set" "api_linkedca" {
+  project      = var.project_id
+  name         = "linkedca.api.${google_dns_managed_zone.default.dns_name}"
+  ttl          = 300
+  type         = "A"
+  managed_zone = google_dns_managed_zone.default.name
+  rrdatas      = [google_compute_address.smallstep_address.address]
+}
+
 resource "google_dns_record_set" "web_api_gateway" {
   project      = var.project_id
   name         = "gateway.api.${google_dns_managed_zone.default.dns_name}"

--- a/gcp/outputs.tf
+++ b/gcp/outputs.tf
@@ -24,6 +24,10 @@ output "dns_scim_domain" {
   value = trimsuffix(google_dns_record_set.web_api_scim.name, ".")
 }
 
+output "dns_linkedca_domain" {
+  value = trimsuffix(google_dns_record_set.api_linkedca.name, ".")
+}
+
 output "dns_zone" {
   value = google_dns_managed_zone.default.dns_name
 }


### PR DESCRIPTION
Could we go ahead and merge this for GCP, then @J-Hunter-Hawke can follow up for AWS and Azure? This will unblock deploying and testing in our internal dev GCP instance.