### PR TITLE
Linkedca aws azure

### DIFF
--- a/aws/dns.tf
+++ b/aws/dns.tf
@@ -113,3 +113,10 @@ resource "aws_route53_record" "scif" {
   records = concat(aws_eip.cluster[*].public_ip)
 }
 
+resource "aws_route53_record" "linkedca_api" {
+  zone_id = aws_route53_zone.cluster.id
+  name    = "linkedca.api.${aws_route53_zone.cluster.name}"
+  ttl     = 300
+  type    = "A"
+  records = concat(aws_eip.cluster[*].public_ip)
+}

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -49,6 +49,10 @@ output "route53_gateway_domain" {
   value = trimsuffix(aws_route53_record.web_api_gateway.name, ".")
 }
 
+output "route53_linkedca_api_domain" {
+  value = trimsuffix(aws_route53_record.linkedca_api.name, ".")
+}
+
 output "route53_name_servers" {
   value = aws_route53_zone.cluster.name_servers
 }

--- a/azure/dns.tf
+++ b/azure/dns.tf
@@ -99,3 +99,11 @@ resource "azurerm_dns_a_record" "approvalq" {
   ttl                 = 300
   records             = [azurerm_public_ip.smallstep_address.ip_address]
 }
+
+resource "azurerm_dns_a_record" "linkedca_api" {
+  name                = "linkedca.api"
+  zone_name           = azurerm_dns_zone.default.name
+  resource_group_name = azurerm_resource_group.smallstep.name
+  ttl                 = 300
+  records             = [azurerm_public_ip.smallstep_address.ip_address]
+}


### PR DESCRIPTION
Alan added the linkedca_api route to GCP yesterday. This PR adds them to both AWS and Azure as well.