### PR TITLE
back to a "runnable" state

### DIFF
--- a/aws/resources/lb/post-policy.sh
+++ b/aws/resources/lb/post-policy.sh
@@ -1,7 +1,7 @@
 test -n "$1" && echo REGION is "$1" || "echo REGION is not set && exit"
 test -n "$2" && echo CLUSTER is "$2" || "echo CLUSTER is not set && exit"
 test -n "$3" && echo ACCOUNT is "$3" || "echo ACCOUNT is not set && exit"
-test -n "$LBC_VERSION" && echo LBC_VERSION is "$LBC_VERSION" || "export LBC_VERSION=2.1.0"
+test -n "$LBC_VERSION" && echo LBC_VERSION is "$LBC_VERSION" || "export LBC_VERSION=2.4.4"
 helm repo add eks https://aws.github.io/eks-charts
 # install the load balancer controller using the helm chart 
 helm upgrade -i aws-load-balancer-controller eks/aws-load-balancer-controller -n kube-system --set clusterName=$2 --set serviceAccount.name=aws-load-balancer-controller --set image.repository=602401143452.dkr.ecr.$1.amazonaws.com/amazon/aws-load-balancer-controller --set image.tag="v$4"

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -41,7 +41,7 @@ variable "default_name" {
 }
 
 variable "k8s_alb_controller_version" {
-  default     = "2.4.1"
+  default     = "2.4.4"
   description = "Version of the aws-load-balancer-controller to run in the cluster."
   type        = string
 }
@@ -119,14 +119,14 @@ variable "redis_desired_params" {
 
 # Must be AT LEAST "6.2"
 variable "redis_engine_version" {
-  default     = "6.2"
+  default     = "6.x"
   description = "Desired engine version for the Redis instance."
   type        = string
 }
 
 # Must be AT LEAST "redis6.0"
 variable "redis_family" {
-  default     = "redis6.0"
+  default     = "redis6.x"
   description = "Desired family for the Redis instance."
   type        = string
 }


### PR DESCRIPTION
EKS has (at some point in the last 6 months) changed its behavior regarding volume mounting. One must now manually install the EBS CSI tooling and grant further EC2 rights before the cluster will be able to mount persistent volumes.