### PR TITLE
Fix DNS record names for att and river.infra

### DIFF
--- a/azure/dns.tf
+++ b/azure/dns.tf
@@ -124,16 +124,16 @@ resource "azurerm_dns_a_record" "inventory" {
   records             = [azurerm_public_ip.smallstep_address.ip_address]
 }
 
-resource "azurerm_dns_a_record" "att_dev" {
-  name                = "att.dev"
+resource "azurerm_dns_a_record" "att" {
+  name                = "att"
   zone_name           = azurerm_dns_zone.default.name
   resource_group_name = azurerm_resource_group.smallstep.name
   ttl                 = 300
   records             = [azurerm_public_ip.smallstep_address.ip_address]
 }
 
-resource "azurerm_dns_a_record" "river_infra_dev" {
-  name                = "river.infra.dev"
+resource "azurerm_dns_a_record" "river_infra" {
+  name                = "river.infra"
   zone_name           = azurerm_dns_zone.default.name
   resource_group_name = azurerm_resource_group.smallstep.name
   ttl                 = 300


### PR DESCRIPTION
## Summary

Fixes incorrect record names added in #34. The base domain already includes `.dev` (`dev.azure.onprem.step.plumbing`), so the subdomain labels should not repeat it.

| Before | After |
|--------|-------|
| `att.dev.<base_domain>` | `att.<base_domain>` |
| `river.infra.dev.<base_domain>` | `river.infra.<base_domain>` |

Also renames the Terraform resource IDs from `att_dev`/`river_infra_dev` to `att`/`river_infra` to match.

## Test plan
- [ ] `terraform plan` shows the two records being recreated with corrected names
- [ ] After apply, confirm `att.dev.azure.onprem.step.plumbing` and `river.infra.dev.azure.onprem.step.plumbing` resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)